### PR TITLE
adicionados campos opcionais do twygo para serem gerados na integração do woocommerce

### DIFF
--- a/twygo-woocommerce/twygo-woocommerce.php
+++ b/twygo-woocommerce/twygo-woocommerce.php
@@ -100,7 +100,14 @@ function send_to_twygo( $post_ID ) {
         'last_name' => $order->billing_last_name,
         'email' => $order->billing_email,
         'enterprise' => empty($order->billing_company) ? 'WooCommerce' : $order->billing_company,
-        'events_external_ids' => $external_ids
+        'events_external_ids' => $external_ids,
+        'city' => empty($order->billing_city) ? 'WooCommerce' : $order->billing_city,
+        'state' => empty($order->billing_state) ? 'WooCommerce' : $order->billing_state,
+        'country' => empty($order->billing_country) ? 'Brasil' : $order->billing_country,
+        'phone1' => empty($order->billing_phone) ? '(99) 9999-9999' : $order->billing_phone,
+        'phone2' => empty($order->billing_phone) ? '(99) 9999-9999' : $order->billing_phone,
+        'address' => empty($order->billing_address_1) ? 'WooCommerce' : $order->billing_address_1,
+        'address2' => empty($order->billing_address_2) ? 'WooCommerce' : $order->billing_address_2
       );
       $url = get_option( 'url_twygo' ) == false ? 'https://www.twygoead.com' : get_option( 'url_twygo' );
       $token = getToken($data, get_option( 'email_twygo' ), get_option( 'password_twygo' ), $url);


### PR DESCRIPTION
#### :rage: PROBLEMA
Falha ao cadastrar pedidos pelo wordpress

#### :sweat_smile: SOLUÇÃO
Adicionados campos opcionais do twygo no plugin

#### :bug: TESTES
Não se aplica

#### :heavy_check_mark: ATIVIDADE
https://app.artia.com/a/324525/f/2177882/activities/20070493

#### :hammer_and_wrench: Tipo de mudança
 - [x] Correção de bug (alteração ininterrupta que corrige um problema)
 - [ ] Novo recurso (mudança ininterrupta que adiciona funcionalidade)
 - [ ] Refatoração (Mudança no código que mantém o funcionamento como esperado)
 - [x] Esta mudança requer uma atualização de documentação

#### :checkered_flag: CHECKLIST
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Eu fiz uma autoavaliação do meu próprio código
- [ ] Eu adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [ ] Testes unitários novos e existentes continuam passando, mesmo com minhas alterações